### PR TITLE
Update setup.sh

### DIFF
--- a/nginx-initd.sh
+++ b/nginx-initd.sh
@@ -10,8 +10,20 @@
 # Description:       starts nginx using start-stop-daemon
 ### END INIT INFO
 
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/nginx
+#Tested on Debian-8.0-x86_64-minimal
+platform='default'
+if [ "$(. /etc/os-release; echo $NAME)" = "Debian GNU/Linux" ]; then
+  echo Running on Debian
+  platform='debian'
+fi
+
+if [ $platform = 'debian' ]; then
+   DAEMON=/opt/sbin/nginx
+   PATH=/opt/bin:/opt/sbin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+elif [ $platform = 'default' ]; then
+   DAEMON=/usr/sbin/nginx
+   PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+fi
 NAME=nginx
 DESC=nginx
 

--- a/setup.sh
+++ b/setup.sh
@@ -53,7 +53,7 @@ apt -y dist-upgrade
 apt-get -y install build-essential make gcc
 apt-get -y build-dep nginx
 # Some setups fail to install certain dependencies so they are manually specified below.
-apt-get install libpcre3 libpcre3-dev libssl-dev
+apt-get -y install libpcre3 libpcre3-dev libssl-dev
 
 # Change into LUAJIT Directory
 cd LuaJIT-2.0.5
@@ -109,8 +109,8 @@ touch /usr/local/nginx/logs/error.log
 
 # Get init.d script
 wget -O /etc/init.d/nginx https://raw.githubusercontent.com/nsuchy/nginx-naxsi-installer/master/nginx-initd.sh
-sudo chmod +x /etc/init.d/nginx
-sudo /usr/sbin/update-rc.d -f nginx defaults
+chmod +x /etc/init.d/nginx
+/usr/sbin/update-rc.d -f nginx defaults
 
 # Switches default configuration files with a sane configuration from the repo and sets up virtual hosts
 mkdir /usr/local/nginx/conf/conf.d/


### PR DESCRIPTION
The missing -y makes users have to manually type "y" into the console when the script is ran.

The two lines I changed are the only lines that use the command "sudo"
This breaks the script for minimal setups (e.g. "Ubuntu-16.04-x86_64-minimal") that do not have the sudo command.

It is unnecessary for sudo to be here and thus I suggest you remove it.
In my situation, I had to go back and manually type these commands since I have no sudo.

E.g. "./setup.sh: 112: ./setup.sh: sudo: not found"

- sidenote: as of right now, it the nginx init.d script fails on Debian and thus is unusable on an Debian environment however since this script is designed for Ubuntu, this technically isn't an issue for you.
- Fixed this issue here https://github.com/andrewsalmon/nginx-naxsi-installer/commit/1cdaf3e18696c0076271e6b4e6f58f88b5609b49